### PR TITLE
Error budget tweaks

### DIFF
--- a/measurements/NavSatellite.m
+++ b/measurements/NavSatellite.m
@@ -457,6 +457,8 @@ classdef NavSatellite < handle
                 % pseudorange uncertainty from clock model
                 var.psr.clk = reshape(Pmdl(7,7,:) + Pprop(7,7,:), [1 n 1]) * obj.c^2;               % m^2
                 % velocity uncertainty from clock model
+                % TODO: FLL measurement is based on subsequent phase
+                % observations separated by T_c like the PLL
                 if PLL
                     temp = obj.clock.dtcovariance(user.rec.Tm);
                     var.psrr.clk = ones(1,n) * temp(1,1) * (obj.c * 1e3 / user.rec.Tm)^2;           % mm^2/s^2

--- a/measurements/Receiver.m
+++ b/measurements/Receiver.m
@@ -42,8 +42,13 @@ classdef Receiver < handle
         % bit transition time so it can bet two samples to form the
         % discriminator; doesn't matter if data = 0 (default AFS-complaint)
         T_c         (1,1)   double {mustBePositive} = 0.002
-        % s, delta pseudorange measurement spacing to derive rate (default 1s)
-        Tm          (1,1)   double {mustBePositive} = 1
+        % s, phase measurement spacing to derive rate (default 0s). If Tm <
+        % T_c, then T_c is used to derive rate (like in the case of a FLL).
+        % If Tm > T_c, Tm is used; this is mainly for PLLs when you want a
+        % more accurate measurement because you have the full phase counts
+        % for that whole time. Similar techniques may be implementable for
+        % a FLL?
+        Tm          (1,1)   double {mustBeNonnegative} = 0
     end
 
     properties (Access = private)


### PR DESCRIPTION
These commits fix pseudorange-rate (Doppler) calculations for a receiver with a PLL or FLL. Previously, the PLL computed Doppler via two time-averaged phase measurements separated by a user-defined time. The noise applied was the Allan variance. Now, to align the computations with reality, both loops compute Doppler via time-averaged phase measurements separated by the predetection integration time; increasing the spacing is a separate option, `Tm`, that may only be applicable to PLLs. The noise applied is the s/c frequency offset (or, uncertainty) plus the Allan variance (frequency stability).